### PR TITLE
use a module as formatter instead of function ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ By default, metrics are formatted using `Elixometer.Utils.name_to_exometer/2`.
 This function takes care of composing metric names with prefix, environment and
 the metric type (e.g. `myapp_prefix.dev.timers.request_time`).
 
-This behaviour can be overridden with a custom formatter function, by adding the
-following configuration entry:
+This behaviour can be overridden with a custom formatter module (implementing the
+`Elixometer.Formatter` behaviour) by adding the following configuration entry:
 
 ```elixir
 config :elixometer, Elixometer.Updater,
-  formatter: &MyApp.Metrics.my_custom_formatter/2
+  formatter: MyApp.Formatter
 ```
 
 Elixometer uses [`pobox`](https://github.com/ferd/pobox) to prevent overload.

--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -1,0 +1,3 @@
+defmodule Elixometer.Formatter do
+  @callback format(String.t(), String.t()) :: [String.t()]
+end

--- a/lib/updater.ex
+++ b/lib/updater.ex
@@ -2,7 +2,7 @@ defmodule Elixometer.Updater do
   @moduledoc false
 
   @max_messages 1000
-  @default_formatter &Elixometer.Utils.name_to_exometer/2
+  @default_formatter Elixometer.Utils
 
   import Elixometer, only: [ensure_registered: 2, add_counter: 2, add_counter: 1]
   use GenServer
@@ -52,7 +52,7 @@ defmodule Elixometer.Updater do
   end
 
   def do_update({:histogram, name, delta, aggregate_seconds, truncate}, formatter) do
-    monitor = formatter.(:histograms, name)
+    monitor = formatter.format(:histograms, name)
 
     ensure_registered(monitor, fn ->
       :exometer.new(
@@ -67,7 +67,7 @@ defmodule Elixometer.Updater do
   end
 
   def do_update({:spiral, name, delta, opts}, formatter) do
-    monitor = formatter.(:spirals, name)
+    monitor = formatter.format(:spirals, name)
 
     ensure_registered(monitor, fn ->
       :exometer.new(monitor, :spiral, opts)
@@ -77,7 +77,7 @@ defmodule Elixometer.Updater do
   end
 
   def do_update({:counter, name, delta, reset_seconds}, formatter) do
-    monitor = formatter.(:counters, name)
+    monitor = formatter.format(:counters, name)
 
     ensure_registered(monitor, fn ->
       :exometer.new(monitor, :counter, [])
@@ -93,7 +93,7 @@ defmodule Elixometer.Updater do
   end
 
   def do_update({:gauge, name, value}, formatter) do
-    monitor = formatter.(:gauges, name)
+    monitor = formatter.format(:gauges, name)
 
     ensure_registered(monitor, fn ->
       :exometer.new(monitor, :gauge, [])
@@ -103,7 +103,7 @@ defmodule Elixometer.Updater do
   end
 
   def do_update({:timer, name, units, elapsed_us}, formatter) do
-    timer = formatter.(:timers, name)
+    timer = formatter.format(:timers, name)
 
     ensure_registered(timer, fn ->
       :exometer.new(timer, :histogram, [])

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -1,5 +1,8 @@
 defmodule Elixometer.Utils do
   @moduledoc false
+  @behaviour Elixometer.Formatter
+
+  def format(metric_type, name), do: name_to_exometer(metric_type, name)
 
   # Name may already have been converted elsewhere.
   def name_to_exometer(_metric_type, name) when is_list(name) do


### PR DESCRIPTION
Because Distillery barfs when a function ref is used in a config file, we change the formatter configuration to use a module implementing the new `Elixometer.Formatter` behaviour. This will provide additional safety for those interested in configuring their own formatter.